### PR TITLE
Add fry-0 bio

### DIFF
--- a/docs/fry.md
+++ b/docs/fry.md
@@ -1,0 +1,6 @@
+# GitHub fry-0
+
+- **Name:** Francesco
+- **Occupation:** HPC specialist, automotive consultant
+- **Location:** Italy
+


### PR DESCRIPTION
This request adds a bio file for @fry-0 as requested in issue #10.

GitHub rocks :+1: 
